### PR TITLE
BC: filename() and destination()

### DIFF
--- a/tests/ImageTest.php
+++ b/tests/ImageTest.php
@@ -40,7 +40,7 @@ class ImageTest extends TestCase
         $expected = '8fold-jewel-small.jpg';
 
         $result = Image::atLocalPath(__DIR__ . '/test-files/8fold-jewel-small.jpg')
-            ->filename(includePath: false);
+            ->filename();
 
         $this->assertSame(
             $expected,


### PR DESCRIPTION
filename() now returns only the filename.

destination() returns the fully qualified path.

All $filename arguments and properties have been changed to $destination.

[Describe what this PR is about]

## List of issues fixed

[Please use GitHub notation to automatically close the issues: Fixes #{issue number}]
